### PR TITLE
Promote moderators when the last admin in the room leaves

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,10 @@ modules:
       unfreeze_blacklist:
         - evil.com
         - foo.com
+      # Optional: if set to true, when the last admin in a room leaves it, the module will
+      #   try to promote any moderator (or user with the highest power level) as admin. In
+      #   this mode, it will only freeze the room if it can't find any user to promote.
+      promote_moderators: false
 ```
 
 ## Development and Testing

--- a/README.md
+++ b/README.md
@@ -39,8 +39,9 @@ modules:
         - evil.com
         - foo.com
       # Optional: if set to true, when the last admin in a room leaves it, the module will
-      #   try to promote any moderator (or user with the highest power level) as admin. In
-      #   this mode, it will only freeze the room if it can't find any user to promote.
+      # try to promote any moderator (or user with the highest power level) as admin. In
+      # this mode, it will only freeze the room if it can't find any user to promote.
+      # Defaults to false.
       promote_moderators: false
 ```
 

--- a/freeze_room/__init__.py
+++ b/freeze_room/__init__.py
@@ -464,7 +464,7 @@ def _get_users_with_highest_nondefault_pl(
 
         # Figure out which users will need promoting: every user with the max power level
         # that's still in the room (or have a pending invite to it).
-        users_to_promote = (
+        users_to_promote = tuple(
             user_id
             for user_id, pl in users_dict_copy.items()
             if pl == max_pl
@@ -479,9 +479,15 @@ def _get_users_with_highest_nondefault_pl(
             return users_to_promote
 
         # Otherwise, remove the users we've considered and start again.
+        # We do it in two loops because we can't delete from users_dict_copy while
+        # iterating over it.
+        users_to_delete = []
         for user_id, pl in users_dict_copy.items():
             if pl == max_pl:
-                del users_dict_copy[user_id]
+                users_to_delete.append(user_id)
+
+        for user_id in users_to_delete:
+            del users_dict_copy[user_id]
 
 
 def _get_membership(

--- a/freeze_room/__init__.py
+++ b/freeze_room/__init__.py
@@ -473,7 +473,7 @@ def _get_users_with_highest_nondefault_pl(
         # pending invite to it): those are the users we need to promote.
         users_to_promote = tuple(
             user_id
-            for user_id, pl in users_with_max_pl
+            for user_id in users_with_max_pl
             if (
                 _get_membership(user_id, state_events)
                 in [Membership.JOIN, Membership.INVITE]

--- a/setup.py
+++ b/setup.py
@@ -46,6 +46,7 @@ setup(
     description="A third-party rules module for Synapse to automatically freeze a room when the last admin leaves it and allow other members to unfreeze them and become the new admin.",
     use_scm_version=True,
     setup_requires=["setuptools_scm"],
+    install_requires=["attrs"],
     long_description=read_file(("README.md",)),
     long_description_content_type="text/markdown",
     url="https://github.com/matrix-org/synapse-freeze-room",

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -36,7 +36,6 @@ def create_module(config_override={}, server_name="example.com") -> FreezeRoom:
     module_api.create_and_send_event_into_room = AsyncMock()
     module_api.get_qualified_user_id.side_effect = get_qualified_user_id
 
-    config = config_override
-    config.setdefault("unfreeze_blacklist", [])
+    config = FreezeRoom.parse_config(config_override)
 
     return FreezeRoom(config, module_api)

--- a/tests/test_room_freeze.py
+++ b/tests/test_room_freeze.py
@@ -331,7 +331,7 @@ class RoomFreezeTest(aiounittest.AsyncTestCase):
         # Check that we get the right result back from the callback.
         allowed, replacement = await module.check_event_allowed(leave_event, self.state)
         self.assertTrue(allowed)
-        self.assertEqual(replacement, leave_event.get_dict())
+        self.assertEqual(replacement, None)
 
         # Test that a new event was sent into the room.
         self.assertTrue(module._api.create_and_send_event_into_room.called)
@@ -372,7 +372,7 @@ class RoomFreezeTest(aiounittest.AsyncTestCase):
             new_leave_event, self.state,
         )
         self.assertTrue(allowed)
-        self.assertEqual(replacement, new_leave_event.get_dict())
+        self.assertEqual(replacement, None)
 
         # Test that a new event was sent into the room.
         self.assertTrue(module._api.create_and_send_event_into_room.called)

--- a/tests/test_room_freeze.py
+++ b/tests/test_room_freeze.py
@@ -296,7 +296,7 @@ class RoomFreezeTest(aiounittest.AsyncTestCase):
 
         allowed, replacement = await module.check_event_allowed(leave_event, self.state)
         self.assertTrue(allowed)
-        self.assertEqual(replacement, leave_event.get_dict())
+        self.assertEqual(replacement, None)
 
         # Test that the leave triggered a freeze of the room.
         self.assertTrue(module._api.create_and_send_event_into_room.called)


### PR DESCRIPTION
Promote users with the highest non-default PL to admins when the last admin in the room leaves it. If none of these users are currently in the room, look for the next highest PL.
Also did some refactoring around these checks because the code was getting a bit out of hand.

TODO:

* [x] Don't return if every user with the highest PL has left the room
* [x] Write tests for this